### PR TITLE
Included encoding option

### DIFF
--- a/bin/jsgettext
+++ b/bin/jsgettext
@@ -28,7 +28,8 @@ use Jsgettext\Jsgettext,
 $options = array(
     'files' => array(),
     '-o'    => null,
-    '-k'    => '_'
+    '-k'    => '_',
+    '-c'    => 'UTF-8'
 );
 $i = 1;
 
@@ -47,12 +48,18 @@ while ($i < count($argv)) {
 }
 
 try {
-    new Jsgettext($options['files'], $options['-o'], explode(' ', $options['-k']), true);
+    new Jsgettext(
+        $options['files'], 
+        $options['-o'], 
+        explode(' ', $options['-k']), 
+        true,
+        $options['-c']
+    );
 } catch (Exception $e) {
     fwrite(STDOUT, $e->getMessage() . <<<EOT
 
 
-Usage php jsgettext -o [OUTPUT] -k [KEYWORDS] [FILES]
+Usage php jsgettext -o [OUTPUT] -k [KEYWORDS] -c [ENCODING] [FILES]
 
     -o [OUTPUT]
         specify the .po output file where the keys will be dumped
@@ -60,6 +67,9 @@ Usage php jsgettext -o [OUTPUT] -k [KEYWORDS] [FILES]
     -k [KEYWORDS]
         specify the keywords used to find in the files the strings to be parsed
         eg: __ _ i18n_
+    -c [ENCODING]
+        specify the encoding of the .po output file
+        eg: UTF-8
     [FILES]
         files list to be parsed
         eg: ../file.js ../anotherfile.html ../still/anotherfile.js

--- a/src/Jsgettext/Dumper/PoeditDumper.php
+++ b/src/Jsgettext/Dumper/PoeditDumper.php
@@ -27,18 +27,17 @@ class PoeditDumper implements DumperInterface
     *   @param PoeditFile   $file
     *   @param string       $filename
     *   @param boolean      $sort       if enabled, sort strings and their comments. implemented to avoid too many git conflicts
+    *   @param string       $enc
     *
     *   @return boolean
     */
-    public function dump(PoeditFile $file, $filename = null, $sort = false)
+    public function dump(PoeditFile $file, $filename = null, $sort = false, $enc = 'UTF-8')
     {
         $filename = null !== $filename ? $filename : $this->file;
         $content = $file->getHeaders() . PHP_EOL . PHP_EOL;
 
-        $content .= "\"Content-Type: text/plain; charset=UTF-8\\n\"" . PHP_EOL .
-                    "\"Content-Transfer-Encoding: 8bit\\n\"" . PHP_EOL .
-                    "\"X-Generator: Poedit 1.5.4\\n\"" . PHP_EOL .
-                    "\"X-Poedit-SourceCharset: UTF-8\\n\"" . PHP_EOL;
+        $content .= "\"Content-Type: text/plain; charset=" . $enc . "\\n\"" . PHP_EOL;
+                    // "\"X-Poedit-SourceCharset: UTF-8\\n\"" . PHP_EOL;
 
         $strings = true === $sort ? $file->sortStrings()->getStrings() : $file->getStrings();
 

--- a/src/Jsgettext/Jsgettext.php
+++ b/src/Jsgettext/Jsgettext.php
@@ -11,7 +11,14 @@ use Jsgettext\Poedit\PoeditFile,
 
 class Jsgettext
 {
-    public function __construct(array $files, $output, array $keywords = array('_'), $cli = false)
+    public function __construct
+    (
+        array $files, 
+        $output, 
+        array $keywords = array('_'), 
+        $cli = false,
+        $enc = 'UTF-8'
+    )
     {
         $this->cli = $cli;
 
@@ -31,6 +38,6 @@ class Jsgettext
         }
 
         $poeditDumper = new PoeditDumper($output);
-        $poeditDumper->dump($poeditFile);
+        $poeditDumper->dump($poeditFile, null, false, $enc);
     }
 }


### PR DESCRIPTION
Poedit doesn't work right when you are using a .po without a Content-Type header. I have just included an option to add the encoding charset and fix a compatibility problem with Poedit.
