### PR TITLE
remove use statement with non-compound name Exception

### DIFF
--- a/bin/dumper
+++ b/bin/dumper
@@ -20,8 +20,6 @@ set_time_limit(0);
 
 require_once JSGETTEXT_COMPOSER_INSTALL;
 
-use \Exception;
-
 use Xgettext\Dumper\JsonDumper,
     Xgettext\Parser\PoeditParser;
 


### PR DESCRIPTION
I think it's linked to my version of php, but I have this error : 

```
PHP Warning:  The use statement with non-compound name 'Exception' has no effect in /srv/wisembly/vendor/wisembly/xgettext/bin/dumper on line 23
```

The solution I found is to remove the ```use \Exception``` statement